### PR TITLE
chore: update Hugo modules (2025-11-20)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03 // indirect
 	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
 	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect
-	github.com/hugolify/hugolify-theme v1.26.20 // indirect
+	github.com/hugolify/hugolify-theme v1.26.21 // indirect
 	github.com/midzer/tobii v3.0.0+incompatible // indirect
 	github.com/orestbida/cookieconsent v3.1.0+incompatible // indirect
 	github.com/sebousan/hugolify-content-uncinqify v0.0.0-20251113100929-9d6cb03a0958 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWw
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 h1:GZxx4Hc+yb0/t3/rau1j8XlAxLE4CyXns2fqQbyqWfs=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mFberT6ZtcchrsDtfvJM7aAH2bDKLdOnruUHl0hlapI=
-github.com/hugolify/hugolify-theme v1.26.20 h1:mDasCqhk725l67tBBsVHhHRb4HyIMowRVWud4jwoxBM=
-github.com/hugolify/hugolify-theme v1.26.20/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/hugolify/hugolify-theme v1.26.21 h1:A8o/Nxkq4WMYaYQT3sv0SUuigqybdI3IMLBmuYpscRo=
+github.com/hugolify/hugolify-theme v1.26.21/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
 github.com/midzer/tobii v3.0.0+incompatible h1:cccjAG0fN1u/kdnquWm/FLYffjX53Dj4kSbWFQSlKLc=
 github.com/midzer/tobii v3.0.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
 github.com/orestbida/cookieconsent v3.1.0+incompatible h1:L2uj16SEL1bICkn6pJde9uc1qAPmTcEiFZO93zZKdQI=
@@ -16,6 +16,7 @@ github.com/sebousan/hugolify-content-uncinqify v0.0.0-20251113100929-9d6cb03a095
 github.com/sebousan/hugolify-content-uncinqify v0.0.0-20251113100929-9d6cb03a0958/go.mod h1:YUYhIdRN11KsFLRPxZJifhXS34O7gqfhkVPK6ZBkw08=
 github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20251113105823-09d942b0a387 h1:vAdzAavMXTtAN5nP/WhTf1fqFRZS9iCS8jkrujsroY4=
 github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20251113105823-09d942b0a387/go.mod h1:qB0HiaLtrnRIzzHYL/M64jxKLjfod06wIGOGGrnkMZ0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=

--- a/hugo_stats.json
+++ b/hugo_stats.json
@@ -103,6 +103,7 @@
       "nav-item-highlighted",
       "nav-legal",
       "nav-primary",
+      "nav-secondary",
       "nav-social",
       "offcanvas",
       "offset-lg-2",


### PR DESCRIPTION

## Date
jeudi 20 novembre 2025

## Statut
✅ Succès

## Modules mis à jour
### go.mod

```diff
@@ -10 +10 @@ require (
-	github.com/hugolify/hugolify-theme v1.26.20 // indirect
+	github.com/hugolify/hugolify-theme v1.26.21 // indirect
```

### go.sum

```diff
@@ -9,2 +9,2 @@ github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mF
-github.com/hugolify/hugolify-theme v1.26.20 h1:mDasCqhk725l67tBBsVHhHRb4HyIMowRVWud4jwoxBM=
-github.com/hugolify/hugolify-theme v1.26.20/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/hugolify/hugolify-theme v1.26.21 h1:A8o/Nxkq4WMYaYQT3sv0SUuigqybdI3IMLBmuYpscRo=
+github.com/hugolify/hugolify-theme v1.26.21/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
```


