### PR TITLE
chore: update Hugo modules (2026-01-01)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03 // indirect
 	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
 	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect
-	github.com/hugolify/hugolify-theme v1.26.21 // indirect
-	github.com/midzer/tobii v3.0.0+incompatible // indirect
+	github.com/hugolify/hugolify-theme v1.26.26 // indirect
+	github.com/midzer/tobii v3.1.0+incompatible // indirect
 	github.com/orestbida/cookieconsent v3.1.0+incompatible // indirect
 	github.com/sebousan/hugolify-content-uncinqify v0.0.0-20251113100929-9d6cb03a0958 // indirect
 	github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20251113105823-09d942b0a387 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,10 @@ github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWw
 github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 h1:GZxx4Hc+yb0/t3/rau1j8XlAxLE4CyXns2fqQbyqWfs=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mFberT6ZtcchrsDtfvJM7aAH2bDKLdOnruUHl0hlapI=
-github.com/hugolify/hugolify-theme v1.26.21 h1:A8o/Nxkq4WMYaYQT3sv0SUuigqybdI3IMLBmuYpscRo=
-github.com/hugolify/hugolify-theme v1.26.21/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
-github.com/midzer/tobii v3.0.0+incompatible h1:cccjAG0fN1u/kdnquWm/FLYffjX53Dj4kSbWFQSlKLc=
-github.com/midzer/tobii v3.0.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
+github.com/hugolify/hugolify-theme v1.26.26 h1:/GM0YGnJEdpdPemO8hEKAB/geXLp/qvFjngNAfclu/k=
+github.com/hugolify/hugolify-theme v1.26.26/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/midzer/tobii v3.1.0+incompatible h1:4eV2tjsk0NFYRtbufY16dZzaBBHPgl6Wvsc3ryydHnw=
+github.com/midzer/tobii v3.1.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
 github.com/orestbida/cookieconsent v3.1.0+incompatible h1:L2uj16SEL1bICkn6pJde9uc1qAPmTcEiFZO93zZKdQI=
 github.com/orestbida/cookieconsent v3.1.0+incompatible/go.mod h1:8N46VI/40AwvzASJDpiwfbu6zylSzKSDZRUVNmVXLxw=
 github.com/sebousan/hugolify-content-uncinqify v0.0.0-20251113100929-9d6cb03a0958 h1:wF3f7suRO0EDic3Nr2kJmPKDxNjL9v08wAKzn24D5AU=


### PR DESCRIPTION

## Date
Thursday, January 1, 2026

## Status
✅ Success

## Updated modules
### go.mod

```diff
@@ -10,2 +10,2 @@ require (
-	github.com/hugolify/hugolify-theme v1.26.21 // indirect
-	github.com/midzer/tobii v3.0.0+incompatible // indirect
+	github.com/hugolify/hugolify-theme v1.26.26 // indirect
+	github.com/midzer/tobii v3.1.0+incompatible // indirect
```

### go.sum

```diff
@@ -9,4 +9,4 @@ github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mF
-github.com/hugolify/hugolify-theme v1.26.21 h1:A8o/Nxkq4WMYaYQT3sv0SUuigqybdI3IMLBmuYpscRo=
-github.com/hugolify/hugolify-theme v1.26.21/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
-github.com/midzer/tobii v3.0.0+incompatible h1:cccjAG0fN1u/kdnquWm/FLYffjX53Dj4kSbWFQSlKLc=
-github.com/midzer/tobii v3.0.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
+github.com/hugolify/hugolify-theme v1.26.26 h1:/GM0YGnJEdpdPemO8hEKAB/geXLp/qvFjngNAfclu/k=
+github.com/hugolify/hugolify-theme v1.26.26/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/midzer/tobii v3.1.0+incompatible h1:4eV2tjsk0NFYRtbufY16dZzaBBHPgl6Wvsc3ryydHnw=
+github.com/midzer/tobii v3.1.0+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
@@ -19 +18,0 @@ github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20251113105823-09d942b0a387/
-github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
```


