### PR TITLE
chore: update Hugo modules (2026-04-01)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.21
 require (
 	github.com/Splidejs/splide v4.1.3+incompatible // indirect
 	github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03 // indirect
-	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
+	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800 // indirect
 	github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 // indirect
-	github.com/hugolify/hugolify-theme v1.27.4 // indirect
+	github.com/hugolify/hugolify-theme v1.27.14 // indirect
 	github.com/midzer/tobii v3.1.3+incompatible // indirect
 	github.com/orestbida/cookieconsent v3.1.0+incompatible // indirect
 	github.com/sebousan/hugolify-content-uncinqify v0.0.0-20260217135141-3db33fdffca5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/Splidejs/splide v4.1.3+incompatible h1:ms0c3Tem9Bq7qcr88nLspZi2SW14mY
 github.com/Splidejs/splide v4.1.3+incompatible/go.mod h1:N10tHuOP81a5HGua3PmZVrpMiBmf/KhId8jZt0oShNk=
 github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03 h1:TyZM0MK9+09/vGdnH8N9xVFix5f1vzU90V5WCyL16oE=
 github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03/go.mod h1:CJ8UtS8LPLOSmpvwRkQJkwqOwwXaDfH5S7iG83GKAlY=
-github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWwrtijAhUbf3BiRLmpO5j34bgl1ggU=
-github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
+github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800 h1:j5myhhzYwIHTr5ctK96Elfgp5uRROvrlTzYwwe1nF8o=
+github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800/go.mod h1:P5GGyhdxi00C5zW7vkRo/IS532gZY/YS2TS395Xaxho=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000 h1:GZxx4Hc+yb0/t3/rau1j8XlAxLE4CyXns2fqQbyqWfs=
 github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mFberT6ZtcchrsDtfvJM7aAH2bDKLdOnruUHl0hlapI=
-github.com/hugolify/hugolify-theme v1.27.4 h1:uwcMa8PPZZjjO0kqhtN04NIaiwhIjoTbmFytKRvgpQM=
-github.com/hugolify/hugolify-theme v1.27.4/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/hugolify/hugolify-theme v1.27.14 h1:Anx5iO6IG1ierj0qbc9LJU0RgvGIqY7a1BHr8rl2Oxo=
+github.com/hugolify/hugolify-theme v1.27.14/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
 github.com/midzer/tobii v3.1.3+incompatible h1:3h2eGycwcHuTWeBLg5bqCLx3EcPSV1rHT1btiu4A3k0=
 github.com/midzer/tobii v3.1.3+incompatible/go.mod h1:ByXFkVm8ja2+TXT7L+lfkdEIeHW4IdWdsQO8zJ5mEqA=
 github.com/orestbida/cookieconsent v3.1.0+incompatible h1:L2uj16SEL1bICkn6pJde9uc1qAPmTcEiFZO93zZKdQI=
@@ -16,7 +16,6 @@ github.com/sebousan/hugolify-content-uncinqify v0.0.0-20260217135141-3db33fdffca
 github.com/sebousan/hugolify-content-uncinqify v0.0.0-20260217135141-3db33fdffca5/go.mod h1:YUYhIdRN11KsFLRPxZJifhXS34O7gqfhkVPK6ZBkw08=
 github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20260212143707-acfa05f78bc4 h1:cro2xM9kqQsSFi6gfoyFTKRr2zK5QXldoZ2ejdAxmTM=
 github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20260212143707-acfa05f78bc4/go.mod h1:qB0HiaLtrnRIzzHYL/M64jxKLjfod06wIGOGGrnkMZ0=
-github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=


### PR DESCRIPTION

## Date
Wednesday, April 1, 2026

## Status
✅ Success

## Updated modules
### go.mod

```diff
@@ -8 +8 @@ require (
-	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 // indirect
+	github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800 // indirect
@@ -10 +10 @@ require (
-	github.com/hugolify/hugolify-theme v1.27.4 // indirect
+	github.com/hugolify/hugolify-theme v1.27.14 // indirect
```

### go.sum

```diff
@@ -5,2 +5,2 @@ github.com/dixonandmoe/rellax v0.0.0-20240824005335-9ed6cb0aae03/go.mod h1:CJ8Ut
-github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400 h1:L6+F22i76xmeWWwrtijAhUbf3BiRLmpO5j34bgl1ggU=
-github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20400/go.mod h1:uekq1D4ebeXgduLj8VIZy8TgfTjrLdSl6nPtVczso78=
+github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800 h1:j5myhhzYwIHTr5ctK96Elfgp5uRROvrlTzYwwe1nF8o=
+github.com/gohugoio/hugo-mod-bootstrap-scss/v5 v5.20300.20800/go.mod h1:P5GGyhdxi00C5zW7vkRo/IS532gZY/YS2TS395Xaxho=
@@ -9,2 +9,2 @@ github.com/gohugoio/hugo-mod-jslibs-dist/popperjs/v2 v2.21100.20000/go.mod h1:mF
-github.com/hugolify/hugolify-theme v1.27.4 h1:uwcMa8PPZZjjO0kqhtN04NIaiwhIjoTbmFytKRvgpQM=
-github.com/hugolify/hugolify-theme v1.27.4/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
+github.com/hugolify/hugolify-theme v1.27.14 h1:Anx5iO6IG1ierj0qbc9LJU0RgvGIqY7a1BHr8rl2Oxo=
+github.com/hugolify/hugolify-theme v1.27.14/go.mod h1:Rc64eJSSIWGeU6eHfSzUISNfL9UrJmy3Xs3H05Gz9rQ=
@@ -19 +18,0 @@ github.com/sebousan/hugolify-theme-uncinqify v0.0.0-20260212143707-acfa05f78bc4/
-github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
```


